### PR TITLE
Rename tags: Use all caps for abbrevs, else capitalized first letter

### DIFF
--- a/docs/documentation-details.md
+++ b/docs/documentation-details.md
@@ -1,7 +1,7 @@
 ---
 title: Editing details and tools
 tags:
-  - contribute
+  - Contribute
 ---
 
 ## Visual Studio Code

--- a/docs/documentation-howto.md
+++ b/docs/documentation-howto.md
@@ -1,7 +1,7 @@
 ---
 title: Writing Host Mobility Product Documentation
 tags:
-  - contribute
+  - Contribute
 ---
 
 This document describes how to write and publish [Host Mobility Product Documentation](https://hostmobility.github.io/documentation)

--- a/docs/example.md
+++ b/docs/example.md
@@ -1,9 +1,9 @@
 ---
 title: Special
 tags:
-  - c61
-  - hmx
-  - mxv
+  - C61
+  - HMX
+  - MX-V
 ---
 
 
@@ -11,4 +11,4 @@ tags:
 # Special machines
 
 
-Documentation specific to c61, hmx and more.
+Documentation specific to C61, HMX and more.

--- a/docs/interfaces/accelerometer.md
+++ b/docs/interfaces/accelerometer.md
@@ -1,10 +1,10 @@
 ---
 title: Accelerometer
 tags:
-    - hmx
-    - c61
-    - mx4
-    - mxv
+    - HMX
+    - C61
+    - MX-4
+    - MX-V
 ---
 
 ## Overview

--- a/docs/interfaces/c61/leds.md
+++ b/docs/interfaces/c61/leds.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - c61
+  - C61
 ---
 
 LEDS on the C61 are accessed through spi

--- a/docs/interfaces/hmx/accelerometer.md
+++ b/docs/interfaces/hmx/accelerometer.md
@@ -1,7 +1,7 @@
 ---
 title: HMX Accelerometer
 tags:
-    - hmx
+    - HMX
 ---
 
 TODO

--- a/docs/interfaces/hmx/leds.md
+++ b/docs/interfaces/hmx/leds.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - hmx
+  - HMX
 ---
 
 ### The following leds are available on HMX

--- a/docs/interfaces/leds.md
+++ b/docs/interfaces/leds.md
@@ -1,7 +1,7 @@
 ---
 tags:
-  - hmx
-  - c61
+  - HMX
+  - C61
 ---
 
 LEDs are usually* accessed through the [Linux LED subsystem API](https://docs.kernel.org/leds/leds-class.html). 


### PR DESCRIPTION
- Use official names for products, e.g. MX-V, HMX.
- Otherwise capitalize initial letter, e.g. Contribute

Search can find tags regardless of case.