### PR TITLE
MX-4 C61: System upgrade using /boot requires a different file name

### DIFF
--- a/docs/system/mx4/c61/update.md
+++ b/docs/system/mx4/c61/update.md
@@ -9,7 +9,7 @@ tags:
 
 ### Prepare upgrade
 
-* Copy `vf_hmupdate.img` to a USB memory or to `/boot` on the Linux file system
+* Copy `vf_hmupdate.img` to a USB memory or to `/boot/vf_boot.scr` on the Linux file system (renaming the file in the latter case only)
 
 ### If USB method is used
 


### PR DESCRIPTION
Update the full system upgrade instructions to rename the image file to vf_boot.scr when using the /boot method.