### PR TITLE
Document watchdog

### DIFF
--- a/docs/system/hmx/watchdog.md
+++ b/docs/system/hmx/watchdog.md
@@ -1,0 +1,10 @@
+---
+title: Watchdog (HMX)
+tags:
+  - Watchdog
+  - HMX
+---
+
+## Overview
+
+This platform comes with a dedicated watchdog running on the M7 co-processor. Its job is to ensure that the system does not get stuck in a hung state during boot. If the system freezes, it will be forcefully rebooted after 45 seconds.

--- a/docs/system/watchdog.md
+++ b/docs/system/watchdog.md
@@ -1,0 +1,28 @@
+---
+title: Watchdog
+tags:
+  - C61
+  - CT
+  - CT GL
+  - HMX
+  - MX-4
+  - MX-V
+  - T30
+  - T30 FR
+  - Watchdog
+---
+
+## Overview
+
+The reference systems of all our platforms come with a standard Linux watchdog that is *disabled by default*.
+
+To enable this watchdog, simply write to it as follows:
+
+```bash
+echo 1 > /dev/watchdog
+```
+
+This command starts the watchdog timer. If the watchdog is not "fed" again within 60 seconds, the system will reboot. To keep the system running, you must "feed" it periodically by writing to `/dev/watchdog` before the timeout expires.
+
+## Platform specific
+- [HMX](hmx/watchdog.md)


### PR DESCRIPTION
This describes general Linux watchdog usage for all platforms and adds a page for HMX about its M7 watchdog.