### PR TITLE
Update libgpiod-related docs

### DIFF
--- a/docs/interfaces/digital_io.md
+++ b/docs/interfaces/digital_io.md
@@ -23,17 +23,54 @@ Digital I/O is handled by the Linux GPIO subsystem. This is a generic interface 
 - [MX-V](mxv/digital_io.md)
 - [MX-4](mx4/digital_io.md)
 
-## Geting started
-Where possible, it is recommended to use the modern (since Linux v4.8) GPIO API. It is implemented in
-[libgpiod](https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git) and comes
-with bindings also for C++ and Python.
+## Getting started
 
-The library comes with a set of tools that can be used from a shell script to
-set and get values.
+Where possible, it is recommended to use the modern (since Linux v4.8) GPIO API. It is implemented by
+[libgpiod](https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git), which also provides high-level
+bindings for C++, Python, GLib, and Rust.
 
-* gpiodetect - list all gpiochips present on the system, their names, labels and number of GPIO lines
-* gpioinfo   - list all lines of specified gpiochips, their names, consumers, direction, active state and additional flags
-* gpioget    - read values of specified GPIO lines 
-* gpioset    - set values of specified GPIO lines, potentially keep the lines exported and wait until timeout, user input or signal
-* gpiofind   - find the gpiochip name and line offset given the line name 
-* gpiomon    - wait for events on GPIO lines, specify which events to watch, how many events to process before exiting or if the events should be reported to the console
+The library comes with a set of command-line tools that can be used from shell scripts to
+inspect and control GPIO lines:
+
+* `gpiodetect`  -- list all gpiochips present on the system, their names, labels, and number of GPIO lines
+* `gpioinfo`    -- list GPIO lines, their chip, offset, name, direction, and additional attributes
+* `gpioget`     -- read values of specified GPIO lines
+* `gpioset`     -- set values of specified GPIO lines
+* `gpiomon`     -- wait for edge events on GPIO lines
+* `gpionotify`  -- wait for line-info change events on GPIO lines
+
+### libgpiod v1.x
+
+In libgpiod v1.x, GPIO lines are typically addressed by gpiochip and line
+offset. To work with named lines, `gpiofind` can be used to look up the chip
+name and offset first.
+
+Example:
+
+```bash
+gpiofind MODEM_PWR
+gpioset $(gpiofind MODEM_PWR)=0
+gpioget $(gpiofind IN_START)
+```
+
+### libgpiod v2.x
+
+In libgpiod v2.x, `gpiofind` was removed. Its functionality was absorbed into
+the other tools, which can resolve GPIO line names directly.
+
+When using `gpioset`, note that the line state is only maintained while
+the process is running. For scripts, this means that `gpioset` must be
+kept alive long enough for the requested output to remain asserted.
+See the [libgpiod command-line tools documentation](https://libgpiod.readthedocs.io/en/stable/gpio_tools.html)
+for details.
+
+Example:
+
+```bash
+gpioinfo MODEM_PWR
+timeout 0.1 gpioset MODEM_PWR=0
+gpioget IN_START
+gpionotify MODEM_PWR
+```
+
+**Note:** Only the HMX platform currently uses libgpiod v2.x.

--- a/docs/interfaces/hmx/digital_io.md
+++ b/docs/interfaces/hmx/digital_io.md
@@ -39,7 +39,7 @@ Example usage:
 #gpio-leds
 echo 1 > /sys/class/leds/:pwr_out_led_1/brightness
 #gpiod
-gpioset $(gpiofind OUT_SINK1)=1
+timeout 0.1 gpioset OUT_SINK1=1
 ```
 
 ## List of supported inputs

--- a/docs/interfaces/hmx/modem.md
+++ b/docs/interfaces/hmx/modem.md
@@ -19,8 +19,7 @@ root@10210100023:~# gpioinfo | grep MODEM
         line  10:  "MODEM_PWR"       unused   input  active-high
         line  20:  "MODEM_RST"       unused   input  active-high
 
-gpioset $(gpiofind MODEM_PWR)=0
-```
+timeout 0.1 gpioset MODEM_PWR=0
 ```
 
 * The modem takes about 10 seconds to start and register itself with the kernel. It then takes up to one minute before it is registered in the linux usb list.

--- a/docs/interfaces/hmx/start_signal.md
+++ b/docs/interfaces/hmx/start_signal.md
@@ -29,7 +29,7 @@ Example read with unbind gpio-key
 **Note:** This will disable wake-up possibility on digital and start signals.
 ```
 echo gpio-keys > /sys/bus/platform/drivers/gpio-keys/unbind
-gpioget $(gpiofind IN_START)
+gpioget IN_START
 echo gpio-keys > /sys/bus/platform/drivers/gpio-keys/bind
 ```
 


### PR DESCRIPTION
Update gpiod-related documentation to reflect the changes between libgpiod v1.x and v2.x.
Currently, only the HMX platform uses v2.x.