### PR TITLE
Update gpiod-related documentation for MX-V and HMM

### DIFF
--- a/docs/interfaces/digital_io.md
+++ b/docs/interfaces/digital_io.md
@@ -73,4 +73,4 @@ gpioget IN_START
 gpionotify MODEM_PWR
 ```
 
-**Note:** Only the HMX platform currently uses libgpiod v2.x.
+**Note:** All platforms on Yocto 5.0 Scarthgap are (already or soon will be) using libgpiod v2.x.

--- a/docs/interfaces/hmm/io.md
+++ b/docs/interfaces/hmm/io.md
@@ -14,7 +14,7 @@ These pins can also be used to measure current consumption from 0-20mA.
 
 ## IO Modes
 
-| IO | Digital In | Digital Out (source or sink activate) | Analog In | Current Consumption Mode (activate)|
-|----|-----------|------------|-----------|--------------------------|
-| IO1 | `$(gpioget $(gpiofind digital-in-0))` | `gpioset $(gpiofind digital-out-sink-0)=1`<br>`gpioset $(gpiofind digital-out-source-0)=1` | `cat /sys/bus/iio/devices/iio:device0/in_voltage3_raw` | `gpioset $(gpiofind enable-analog-in-20ma-0)=1` |
-| IO2 | `$(gpioget $(gpiofind digital-in-1))` | `gpioset $(gpiofind digital-out-sink-1)=1`<br>`gpioset $(gpiofind digital-out-source-1)=1` | `cat /sys/bus/iio/devices/iio:device0/in_voltage2_raw` | `gpioset $(gpiofind enable-analog-in-20ma-1)=1` |
+| IO | Digital In | Digital Out (source or sink activate) | Analog In | Current Consumption Mode (activate) |
+|----|------------|----------------------------------------|-----------|-------------------------------------|
+| IO1 | `gpioget --numeric digital-in-0` | `timeout 0.1 gpioset digital-out-sink-0=1`<br>`timeout 0.1 gpioset digital-out-source-0=1` | `cat /sys/bus/iio/devices/iio:device0/in_voltage3_raw` | `timeout 0.1 gpioset enable-analog-in-20ma-0=1` |
+| IO2 | `gpioget --numeric digital-in-1` | `timeout 0.1 gpioset digital-out-sink-1=1`<br>`timeout 0.1 gpioset digital-out-source-1=1` | `cat /sys/bus/iio/devices/iio:device0/in_voltage2_raw` | `timeout 0.1 gpioset enable-analog-in-20ma-1=1` |

--- a/docs/interfaces/mxv/digital_io.md
+++ b/docs/interfaces/mxv/digital_io.md
@@ -67,21 +67,22 @@ gpiochip9 - 25 lines:
         line  24: "digital-out-enable" unused input active-high
 ```
 
-To find a specific signal, the `gpiofind` command can be used:
+To inspect a specific signal, pass the line name directly to `gpioinfo`:
 
 ```bash
-root@mxv-pt:~# gpiofind digital-out-enable
-gpiochip9 24
+root@mxv-pt:~# gpioinfo digital-out-enable
 ```
 
 ### Enable digital out
 
 To enable digital out, the `digital-out-enable` line needs to be set to high.
 
-We can use the `gpioset` command in combination with `gpiofind` in `bash`.
+With libgpiod v2.x, GPIO line names can be used directly. Since `gpioset`
+holds the line while the process is running, `timeout` is used here to keep
+the line asserted briefly before returning to the shell.
 
 ```bash
-root@mxv-pt:~# gpioset $(gpiofind digital-out-enable)=1
+root@mxv-pt:~# timeout 0.1 gpioset digital-out-enable=1
 ```
 
 ### Digital out high and low
@@ -92,7 +93,8 @@ are controlled with `digital-out-source-0..7` and the sink drivers with
 cannot be used at the same time.
 
 ```bash
-root@mxv-pt:~# gpioset $(gpiofind digital-out-source-0)=1
+root@mxv-pt:~# timeout 0.1 gpioset digital-out-source-0=1
+root@mxv-pt:~# timeout 0.1 gpioset digital-out-sink-0=1
 ```
 
 ### Over-current sense
@@ -101,7 +103,7 @@ For each digital-out-source-n there is a digital-out-oc-n which can be read to
 detect short-circuits.
 
 ```bash
-root@mxv-pt:~# gpioget $(gpiofind digital-out-oc-0)
+root@mxv-pt:~# gpioget --numeric digital-out-oc-0
 ```
 
 ### Debugging
@@ -151,31 +153,32 @@ root@mxv-pt:~# cat /sys/kernel/debug/gpio | grep -i dig
 ```
 
 ## Digital in
-This unit has 13 digital and analog in (adc) channels using iio devices.
+
+This unit has 13 digital and analog in (ADC) channels using IIO devices.
 
 ```bash
- gpioget $(gpiofind digital-in-1)
- gpioget $(gpiofind digital-in-2)
- gpioget $(gpiofind digital-in-3)
- gpioget $(gpiofind digital-in-4)
- gpioget $(gpiofind digital-in-5)
- gpioget $(gpiofind digital-in-6)
- gpioget $(gpiofind digital-in-7)
- gpioget $(gpiofind digital-in-8)
+gpioget --numeric digital-in-1
+gpioget --numeric digital-in-2
+gpioget --numeric digital-in-3
+gpioget --numeric digital-in-4
+gpioget --numeric digital-in-5
+gpioget --numeric digital-in-6
+gpioget --numeric digital-in-7
+gpioget --numeric digital-in-8
 
- # analog way to access the value
- cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_0_raw
- cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_1_raw
- cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_2_raw
- cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_3_raw
- cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_4_raw
- cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_5_raw
- cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_6_raw
- cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_7_raw
+# Analog way to access the value
+cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_0_raw
+cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_1_raw
+cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_2_raw
+cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_3_raw
+cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_4_raw
+cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_5_raw
+cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_6_raw
+cat /sys/bus/iio/devices/iio:device0/*DIG_IN_AN_7_raw
 
- cat /sys/bus/iio/devices/iio:device0/*AN_IN_AN_1_raw
- cat /sys/bus/iio/devices/iio:device0/*AN_IN_AN_2_raw
- cat /sys/bus/iio/devices/iio:device0/*AN_IN_AN_3_raw
- cat /sys/bus/iio/devices/iio:device0/*AN_IN_AN_4_raw
- cat /sys/bus/iio/devices/iio:device0/*AN_IN_AN_5_raw
+cat /sys/bus/iio/devices/iio:device0/*AN_IN_AN_1_raw
+cat /sys/bus/iio/devices/iio:device0/*AN_IN_AN_2_raw
+cat /sys/bus/iio/devices/iio:device0/*AN_IN_AN_3_raw
+cat /sys/bus/iio/devices/iio:device0/*AN_IN_AN_4_raw
+cat /sys/bus/iio/devices/iio:device0/*AN_IN_AN_5_raw
 ```


### PR DESCRIPTION
All platforms on Yocto 5.0 (Scarthgap) are (already or soon will be) using libgpiod v2.x. Update the documentation accordingly.